### PR TITLE
setup: drop old README.* mangling, intended for README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,6 @@ setup(
 
 	packages=find_packages(),
 	include_package_data=True,
-	package_data={'': ['README.txt']},
-	exclude_package_data={'': ['README.*']},
 
 	entry_points = {
 		'console_scripts': ['sht = sht_sensor.sensor:main'] })


### PR DESCRIPTION
It's a leftover from old README.md days, when my local pre-commit hook converted .md to .rst for package only (as PyPI only formats rst nicely), while keeping .md in the repo.
Now README is .rst anyway, so these two lines are not needed there at all.
(md -> rst point - https://github.com/mk-fg/sht-sensor/commit/42d41541 )

How to test: `python setup.py sdist && tar -tf dist/sht-sensor-18.3.3.tar.gz | grep README` - proper file should be there.